### PR TITLE
Pr/m5stackros/support bluetooth name

### DIFF
--- a/m5stack_ros/include/m5stack_ros.h
+++ b/m5stack_ros/include/m5stack_ros.h
@@ -37,7 +37,7 @@
 // MAX_SUBSCRIBERS, MAX_PUBLISHERS, INPUT_SIZE, OUTPUT_SIZE
 ros::NodeHandle_<ArduinoHardware, 25, 25, 8192, 8192> nh;
 
-void setupM5stackROS() {
+void setupM5stackROS(char *name) {
   M5.begin();
   #if defined(M5STACK)
     M5.Speaker.begin();
@@ -54,5 +54,13 @@ void setupM5stackROS() {
     nh.getHardware()->setBaud(57600);
   #endif
 
+#if defined(ROSSERIAL_ARDUINO_BLUETOOTH)
+  nh.initNode(name);
+#else
   nh.initNode();
+#endif
+}
+
+void setupM5stackROS() {
+    setupM5stackROS("ROSSERIAL_BLUETOOTH");
 }

--- a/m5stack_ros/src/ENV_III/ENV_III.ino
+++ b/m5stack_ros/src/ENV_III/ENV_III.ino
@@ -7,6 +7,8 @@
 // - Adafruit_BMP280 version 2.6.3
 //   https://github.com/adafruit/Adafruit_BMP280_Library
 
+#define ROSSERIAL_ARDUINO_BLUETOOTH
+
 #include <m5stack_ros.h>
 #include <std_msgs/Float32.h>
 #include <M5_ENV_III.h>
@@ -60,7 +62,7 @@ void publishENV() {
 }
 
 void setup() {
-  setupM5stackROS();
+  setupM5stackROS("M5Stack ROS ENVIII");
   setupENV();
 
   nh.advertise(tmp_pub);
@@ -72,5 +74,5 @@ void loop() {
   loopENV();
   publishENV();
   nh.spinOnce();
-  delay(2000);
+  delay(10);
 }


### PR DESCRIPTION
- Enable to give bluetooth device name from setup function.
- Use bluetooth rosserial in ENVIII sample