### PR TITLE
[m5stack_ros] use gcc __TIMESTAMP__ macro as serial number for each d…

### DIFF
--- a/m5stack_ros/include/M5_ENV_III.h
+++ b/m5stack_ros/include/M5_ENV_III.h
@@ -28,11 +28,11 @@ float tmp      = 0.0;
 float hum      = 0.0;
 float pressure = 0.0;
 
-void setupENV() {
-  M5.lcd.setTextSize(2);  // Set the text size to 2.  设置文字大小为2
+void setupENV(std::string device_name) {
+  M5.lcd.setTextSize(1);  // Set the text size to 2.  设置文字大小为2
   Wire.begin();  // Wire init, adding the I2C bus.  Wire初始化, 加入i2c总线
   qmp6988.init();
-  M5.lcd.println(F("ENV Unit III test"));
+  M5.lcd.println(F(device_name.c_str()));
 }
 
 void measureENV() {

--- a/m5stack_ros/include/m5stack_ros.h
+++ b/m5stack_ros/include/m5stack_ros.h
@@ -41,6 +41,18 @@
 // MAX_SUBSCRIBERS, MAX_PUBLISHERS, INPUT_SIZE, OUTPUT_SIZE
 ros::NodeHandle_<ArduinoHardware, 25, 25, 8192, 8192> nh;
 
+std::string getDeviceName(std::string basename) {
+  std::string serial_number( __TIMESTAMP__ );
+#if defined(ROSSERIAL_ARDUINO_TCP)
+  std::string device_name(basename + " with tcp serial burned at " + serial_number);
+#elif defined(ROSSERIAL_ARDUINO_BLUETOOTH)
+  std::string device_name(basename + " with bluetooth serial burned at " + serial_number);
+#else
+  std::string device_name(basename + " with serial burned at " + serial_number);
+#endif
+  return device_name;
+}
+
 void setupM5stackROS(char *name) {
   M5.begin();
   #if defined(M5STACK)

--- a/m5stack_ros/src/ENV_III/ENV_III.ino
+++ b/m5stack_ros/src/ENV_III/ENV_III.ino
@@ -11,6 +11,9 @@
 #include <std_msgs/Float32.h>
 #include <M5_ENV_III.h>
 
+std::string serial_number( __TIMESTAMP__ );
+std::string device_name("M5Stack ROS ENVIII burned at " + serial_number);
+
 std_msgs::Float32 tmp_msg;
 ros::Publisher tmp_pub("temperature", &tmp_msg);
 std_msgs::Float32 hum_msg;
@@ -28,8 +31,10 @@ void publishENV() {
 }
 
 void setup() {
-  setupM5stackROS("M5Stack ROS ENVIII");
-  setupENV();
+  char name[128];
+  strcpy(name, device_name.c_str());
+  setupM5stackROS(name);
+  setupENV(device_name);
 
   nh.advertise(tmp_pub);
   nh.advertise(hum_pub);

--- a/m5stack_ros/src/ENV_III/ENV_III.ino
+++ b/m5stack_ros/src/ENV_III/ENV_III.ino
@@ -7,12 +7,11 @@
 // - Adafruit_BMP280 version 2.6.3
 //   https://github.com/adafruit/Adafruit_BMP280_Library
 
+#define ROSSERIAL_ARDUINO_BLUETOOTH
+
 #include <m5stack_ros.h>
 #include <std_msgs/Float32.h>
 #include <M5_ENV_III.h>
-
-std::string serial_number( __TIMESTAMP__ );
-std::string device_name("M5Stack ROS ENVIII burned at " + serial_number);
 
 std_msgs::Float32 tmp_msg;
 ros::Publisher tmp_pub("temperature", &tmp_msg);
@@ -31,7 +30,8 @@ void publishENV() {
 }
 
 void setup() {
-  char name[128];
+  std::string device_name = getDeviceName("M5Stack ROS ENVIII");
+  char name[256];
   strcpy(name, device_name.c_str());
   setupM5stackROS(name);
   setupENV(device_name);

--- a/m5stack_ros/src/ENV_III/ENV_III_with_battery/ENV_III_with_battery.ino
+++ b/m5stack_ros/src/ENV_III/ENV_III_with_battery/ENV_III_with_battery.ino
@@ -7,6 +7,8 @@
 // - Adafruit_BMP280 version 2.6.3
 //   https://github.com/adafruit/Adafruit_BMP280_Library
 
+#define ROSSERIAL_ARDUINO_BLUETOOTH
+
 #include <m5stack_ros_with_battery.h>
 #include <std_msgs/Float32.h>
 #include <M5_ENV_III.h>
@@ -28,8 +30,11 @@ void publishENV() {
 }
 
 void setup() {
-  setupM5stackROS("M5Stack ROS ENVIII");
-  setupENV();
+  std::string device_name = getDeviceName("M5Stack ROS ENVIII with battery");
+  char name[256];
+  strcpy(name, device_name.c_str());
+  setupM5stackROS(name);
+  setupENV(device_name);
   nh.advertise(tmp_pub);
   nh.advertise(hum_pub);
   nh.advertise(pressure_pub);


### PR DESCRIPTION
…evice

This PR enables to add serial number to each device.
And display it on m5stack and use it as bluetooth device name.