### PR TITLE
Add apt install image-transport-plugins

### DIFF
--- a/m5stack_ros/sketches/TimerCam/README.md
+++ b/m5stack_ros/sketches/TimerCam/README.md
@@ -10,6 +10,11 @@ Install the following packages from Arduino libraries (Tools -> Manage Libraries
   - Please add `#include "soc/adc_channel.h"` to `$HOME/Arduino/libraries/Timer-CAM/src/battery.c`
   - The current origin/master fixes this problem, so version 0.0.3 will not have this problem.
 
+Install the necessary packages with `apt`
+```
+sudo apt install ros-$ROS_DISTRO-image-transport-plugins
+```
+
 ## Overview
 
 Published topics:


### PR DESCRIPTION
Added instructions to the README for image-transport-plugins, which is required to run TimerCam.
Please let me know if there are any corrections.