### PR TITLE
Add rectification node to timer_cam.launch

### DIFF
--- a/m5stack_ros/README.md
+++ b/m5stack_ros/README.md
@@ -148,6 +148,16 @@ Connect the devices to ROS via [M5Stack](https://m5stack.com/) and [rosserial](h
       ```bash
       roslaunch m5stack_ros [device].launch baud:=115200 port:=tcp
       ```
+## Camera calibration
+
+`timer_cam.launch` use camera parameter of a camera.<br>If you want to calibrate camera youself, see [here](http://wiki.ros.org/camera_calibration) and locate yaml file as `/m5stack_ros/config/timer_cam_info.yaml`.
+
+## Published images
+Describe main images here.
+
+`/timer_cam_image` (sensor_msgs/Image)  <br>&emsp;raw color image.
+
+`/timer_cam_image/image_rect_color` (sensor_msgs/Image) <br> &emsp;color image corrected based on camera_info.
 
 ## Devices
 

--- a/m5stack_ros/config/timer_cam_info.yaml
+++ b/m5stack_ros/config/timer_cam_info.yaml
@@ -1,0 +1,26 @@
+image_width: 320
+image_height: 240
+camera_name: camera
+camera_matrix:
+  rows: 3
+  cols: 3
+  data: [ 239.31855,    0.     ,  174.70228,
+            0.     ,  238.39058,  113.35511,
+            0.     ,    0.     ,    1.     ]
+camera_model: plumb_bob
+distortion_coefficients:
+  rows: 1
+  cols: 5
+  data: [-0.366597, 0.138354, 0.000645, 0.001620, 0.000000]
+rectification_matrix:
+  rows: 3
+  cols: 3
+  data: [ 1.,  0.,  0.,
+          0.,  1.,  0.,
+          0.,  0.,  1.]
+projection_matrix:
+  rows: 3
+  cols: 4
+  data: [ 194.37418,    0.     ,  181.68859,    0.     ,
+            0.     ,  213.5239 ,  111.92391,    0.     ,
+            0.     ,    0.     ,    1.     ,    0.     ]

--- a/m5stack_ros/launch/timer_cam.launch
+++ b/m5stack_ros/launch/timer_cam.launch
@@ -24,8 +24,11 @@
     </rosparam>
   </node>
 
-  <node name="image_proc" pkg="image_proc" type="image_proc" output="screen" >
-	<remap from="image_raw" to="$(arg image)" />
-	<remap from="camera_info" to="/camera_info_publisher_with_yaml/camera_info" />
+  <node pkg="nodelet" type="nodelet" name="rectify_timer_cam"
+        args="standalone image_proc/rectify"
+        respawn="true">
+    <remap from="image_mono" to="$(arg image)" />
+    <remap from="image_rect" to="$(arg image)/image_rect_color" />
+    <remap from="camera_info" to="/camera_info_publisher_with_yaml/camera_info" />
   </node>
 </launch>

--- a/m5stack_ros/launch/timer_cam.launch
+++ b/m5stack_ros/launch/timer_cam.launch
@@ -1,5 +1,4 @@
 <launch>
-
   <arg name="port" default="/dev/rfcomm1" />
   <arg name="baud" default="115200" />
   <arg name="image" default="/timer_cam_image" />
@@ -15,5 +14,18 @@
   <node pkg="image_transport" type="republish" name="republish" args="compressed raw">
     <remap from="in" to="$(arg image)" />
     <remap from="out" to="$(arg image)" />
+  </node>
+
+  <node pkg="jsk_interactive_marker" name="camera_info_publisher_with_yaml" type="camera_info_publisher" output="screen">
+    <remap from="~input" to="$(arg image)"/>
+    <rosparam subst_value="true">
+      yaml_filename: $(find m5stack_ros)/config/timer_cam_info.yaml
+      sync_image: true
+    </rosparam>
+  </node>
+
+  <node name="image_proc" pkg="image_proc" type="image_proc" output="screen" >
+	<remap from="image_raw" to="$(arg image)" />
+	<remap from="camera_info" to="/camera_info_publisher_with_yaml/camera_info" />
   </node>
 </launch>


### PR DESCRIPTION
# What is this?

I wanted to use line detction with timer_cam_image, so I included rectification node in `timer_cam.launch`, and added `timer_cam_info.yaml` into /config.
The sample image is pasted below. Left one is rectification image and right one is raw image.

<img src="https://user-images.githubusercontent.com/48650394/188837651-73b644ce-f09f-4f55-b98a-b80d8cad2128.png" width="640px">