### PR TITLE
fix typo in README.md chap.Usage.2

### DIFF
--- a/m5stack_ros/README.md
+++ b/m5stack_ros/README.md
@@ -17,7 +17,7 @@ Connect the devices to ROS via [M5Stack](https://m5stack.com/) and [rosserial](h
     cd ~/m5stack_ros_ws/src
     wstool init
     wstool merge ./jsk-ros-pkg/jsk_3rdparty/m5stack_ros/m5stack_ros.rosinstall
-    wstool up
+    wstool update
     rosdep install --ignore-src --from-paths jsk-ros-pkg/jsk_3rdparty/m5stack_ros -y -r
     cd ~/m5stack_ros_ws
     catkin build m5stack_ros


### PR DESCRIPTION
Fix typo `wstool up` -> `wstool update`