### PR TITLE
[m5stack_ros] Support AtomS3

### DIFF
--- a/m5stack_ros/README.md
+++ b/m5stack_ros/README.md
@@ -47,10 +47,12 @@ Connect the devices to ROS via [M5Stack](https://m5stack.com/) and [rosserial](h
     - Install esp32 by Espressif Systems (Tools -> Board -> Boards Manager -> esp32)
       - Please select version 2.0.0 (> 2.0.1 has bug, 2.0.1 does not work with `TimerCam`).
     - Install M5Stack version 0.3.6 ~ 0.4.0 by [M5Stack](https://github.com/m5stack/M5Stack/tree/0.3.6) (Tools -> Manage Libraries -> M5Stack)
+    - For M5AtomS3, install M5AtomS3 version 0.0.3
     - Select correct board type (Tools -> Board -> ESP32 Arduino)
       - M5Stack Grey/Base: M5Stack-Core-ESP32
       - M5Stack Fire: M5Stack-Fire
       - Timer Camera F: M5Stack-Timer-CAM
+      - M5AtomS3: M5Stack-ATOMS3
 
   - Add dependent libraries to arduino library. This script installs libraries that cannot be installed from the Arduino IDE GUI.
 

--- a/m5stack_ros/README.md
+++ b/m5stack_ros/README.md
@@ -47,7 +47,7 @@ Connect the devices to ROS via [M5Stack](https://m5stack.com/) and [rosserial](h
     - Install esp32 by Espressif Systems (Tools -> Board -> Boards Manager -> esp32)
       - Please select version 2.0.0 (> 2.0.1 has bug, 2.0.1 does not work with `TimerCam`).
     - Install M5Stack version 0.3.6 ~ 0.4.0 by [M5Stack](https://github.com/m5stack/M5Stack/tree/0.3.6) (Tools -> Manage Libraries -> M5Stack)
-    - For M5AtomS3, install M5AtomS3 version 0.0.3
+      - For M5AtomS3, install [M5AtomS3](https://github.com/m5stack/M5AtomS3/tree/1.0.0) version 1.0.0 and [M5Unified](https://github.com/m5stack/M5Unified/tree/0.1.16) version 0.1.16 (Tools -> Manage Libraries)
     - Select correct board type (Tools -> Board -> ESP32 Arduino)
       - M5Stack Grey/Base: M5Stack-Core-ESP32
       - M5Stack Fire: M5Stack-Fire
@@ -105,6 +105,12 @@ Connect the devices to ROS via [M5Stack](https://m5stack.com/) and [rosserial](h
       ```C
       // define nothing
       ```
+
+  - If you use M5AtomS3, define macro at top of `m5stack_ros/arduino_libraries/Grove-Multichannel-Gas-Sensor-V2.h` or `m5stack_ros/arduino_libraries/TGS_Gas_Sensors.h`. When burning, you need to set `USB CDC On Boot: Enabled` and `USB Mode: Hardware CDC and JTAG` in the Tools menu of the Arduino IDE. If you use M5Stack, you don't need define anything.
+
+    ```
+    #define M5ATOM_S3
+    ```
 
   - If you use Wi-Fi, set SSID and password in `m5stack_ros/arduino_libraries/wifi.h`. **DO NOT** upload these information to github.
 
@@ -319,6 +325,7 @@ With the following steps, different symbolic links are created for each M5 devic
 - M5StickC (Only EARTH sensor)
 - M5StickC Plus (Only EARTH sensor)
 - M5Stack Fire (Only SimplePublisher)
+- M5AtomS3 (Only for TGS_Gas_Sensors and Grove-Multichannel-Gas-Sensor-V2, Only checked with USB connection)
 - Timer Camera F (Only TimerCam)
 
 ### Software

--- a/m5stack_ros/arduino_libraries/ArduinoAtomS3Hardware.h
+++ b/m5stack_ros/arduino_libraries/ArduinoAtomS3Hardware.h
@@ -1,0 +1,37 @@
+// The original version of this file is located at https://github.com/sktometometo/smart_device_protocol/blob/develop/arduino_lib/ArduinoAtomS3Hardware.h by sktometometo
+#include <Arduino.h>  // Arduino 1.0
+
+#define SERIAL_CLASS HWCDC
+
+class ArduinoAtomS3Hardware {
+ public:
+  ArduinoAtomS3Hardware(SERIAL_CLASS* io, long baud = 57600) {
+    iostream = io;
+    baud_ = baud;
+  }
+  ArduinoAtomS3Hardware() {
+    iostream = &Serial;
+    baud_ = 57600;
+  }
+  ArduinoAtomS3Hardware(ArduinoAtomS3Hardware& h) {
+    this->iostream = h.iostream;
+    this->baud_ = h.baud_;
+  }
+
+  void setBaud(long baud) { this->baud_ = baud; }
+
+  int getBaud() { return baud_; }
+
+  void init() { iostream->begin(baud_); }
+
+  int read() { return iostream->read(); };
+  void write(uint8_t* data, int length) {
+    for (int i = 0; i < length; i++) iostream->write(data[i]);
+  }
+
+  unsigned long time() { return millis(); }
+
+ protected:
+  SERIAL_CLASS* iostream;
+  long baud_;
+};

--- a/m5stack_ros/arduino_libraries/Grove-Multichannel-Gas-Sensor-V2.h
+++ b/m5stack_ros/arduino_libraries/Grove-Multichannel-Gas-Sensor-V2.h
@@ -23,7 +23,10 @@
     THE SOFTWARE.1  USA
 */
 
-#include <M5Stack.h>
+// You can use M5STACK or M5ATOM_S3
+/* #define M5ATOM_S3 */
+
+#include <m5stack_ros.h>
 #include <Multichannel_Gas_GMXXX.h>
 
 // if you use the software I2C to drive the sensor, you can uncommnet the define SOFTWAREWIRE which in Multichannel_Gas_GMXXX.h.
@@ -61,11 +64,15 @@ void measureGasV2()
 
 void displayGasV2()
 {
-  M5.Lcd.setTextSize(2);
-  M5.Lcd.setCursor(10, 10);
+  #if defined(M5ATOM_S3)
+    M5.Lcd.setTextSize(1);
+  #else
+    M5.Lcd.setTextSize(2);
+  #endif
+  M5.Lcd.setCursor(0, 0);
 
   M5.Lcd.printf("GM102B: %4u = %.2f V\n", val_102B, gas.calcVol(val_102B));
-  M5.Lcd.printf(" GM302B: %4u = %.2f V\n", val_302B, gas.calcVol(val_302B));
-  M5.Lcd.printf(" GM502B: %4u = %.2f V\n", val_502B, gas.calcVol(val_502B));
-  M5.Lcd.printf(" GM702B: %4u = %.2f V\n", val_702B, gas.calcVol(val_702B));
+  M5.Lcd.printf("GM302B: %4u = %.2f V\n", val_302B, gas.calcVol(val_302B));
+  M5.Lcd.printf("GM502B: %4u = %.2f V\n", val_502B, gas.calcVol(val_502B));
+  M5.Lcd.printf("GM702B: %4u = %.2f V\n", val_702B, gas.calcVol(val_702B));
 }

--- a/m5stack_ros/arduino_libraries/TGS_Gas_Sensors.h
+++ b/m5stack_ros/arduino_libraries/TGS_Gas_Sensors.h
@@ -1,8 +1,20 @@
-#include <M5Stack.h>
+/* #include <M5Stack.h> */
+
+// You can use M5STACK or M5ATOM_S3
+#define M5ATOM_S3
+/* #define M5STACK */
+
+#include <m5stack_ros.h>
 #include <Wire.h>
 
-int gas_din=26;
-int gas_ain=36;
+#if defined(M5STACK)
+  int gas_din=26;
+  int gas_ain=36;
+#elif defined(M5ATOM_S3)
+  int gas_din=2;
+  int gas_ain=1;
+#endif
+
 uint16_t analog_value;
 uint16_t digital_value;
 

--- a/m5stack_ros/arduino_libraries/TGS_Gas_Sensors.h
+++ b/m5stack_ros/arduino_libraries/TGS_Gas_Sensors.h
@@ -1,5 +1,3 @@
-/* #include <M5Stack.h> */
-
 // You can use M5STACK or M5ATOM_S3
 #define M5ATOM_S3
 /* #define M5STACK */

--- a/m5stack_ros/arduino_libraries/TGS_Gas_Sensors.h
+++ b/m5stack_ros/arduino_libraries/TGS_Gas_Sensors.h
@@ -1,6 +1,5 @@
 // You can use M5STACK or M5ATOM_S3
-#define M5ATOM_S3
-/* #define M5STACK */
+/* #define M5ATOM_S3 */
 
 #include <m5stack_ros.h>
 #include <Wire.h>
@@ -32,8 +31,12 @@ void measureTGSSensors()
 
 void displayTGSSensors()
 {
-  M5.Lcd.setTextSize(2);
-  M5.Lcd.setCursor(10, 10);
+  #if defined(M5ATOM_S3)
+    M5.Lcd.setTextSize(1);
+  #else
+    M5.Lcd.setTextSize(2);
+  #endif
+  M5.Lcd.setCursor(0, 0);
 
   M5.Lcd.printf("analog_value: %04d\n", analog_value);
   M5.Lcd.printf("digital_value: %01d\n", digital_value);

--- a/m5stack_ros/arduino_libraries/m5stack_ros.h
+++ b/m5stack_ros/arduino_libraries/m5stack_ros.h
@@ -4,7 +4,8 @@
 // If you use M5Stack, define M5STACK
 // If you use M5StickC, define M5STICK_C
 // If you use M5StickC, define M5STICK_C_PLUS
-#if !defined(M5STACK) && !defined(M5STICK_C) && !defined(M5STICK_C_PLUS)
+// If you use M5AtomS3, define M5ATOM_S3
+#if !defined(M5STACK) && !defined(M5STICK_C) && !defined(M5STICK_C_PLUS) && !defined(M5ATOM_S3)
   #define M5STACK
 #endif
 
@@ -14,7 +15,10 @@
   #include <M5StickC.h>
 #elif defined(M5STICK_C_PLUS)
   #include <M5StickCPlus.h>
+#elif defined(M5ATOM_S3)
+  #include <M5AtomS3.h>
 #endif
+
 
 #include <esp_info.h>
 

--- a/m5stack_ros/arduino_libraries/m5stack_ros.h
+++ b/m5stack_ros/arduino_libraries/m5stack_ros.h
@@ -39,8 +39,13 @@
   #define ESP_SERIAL
   #include <ros.h>
 #else
-  #define ESP_SERIAL
-  #include <ros.h>
+  #if defined(M5ATOM_S3)
+    #include <ros.h>
+    #include "ArduinoAtomS3Hardware.h"
+  #else
+    #define ESP_SERIAL
+    #include <ros.h>
+  #endif
 #endif
 
 // If ROSSERIAL_ARDUINO_BLUETOOTH is defined,
@@ -69,11 +74,20 @@
 #ifndef NH_OUTPUT_SIZE
   #define NH_OUTPUT_SIZE 8192
 #endif
-ros::NodeHandle_<ArduinoHardware,
-                 NH_MAX_SUBSCRIBERS,
-                 NH_MAX_PUBLISHERS,
-                 NH_INPUT_SIZE,
-                 NH_OUTPUT_SIZE> nh;
+
+#if defined(M5ATOM_S3)
+  ros::NodeHandle_<ArduinoAtomS3Hardware,
+    NH_MAX_SUBSCRIBERS,
+    NH_MAX_PUBLISHERS,
+    NH_INPUT_SIZE,
+    NH_OUTPUT_SIZE> nh;
+#else
+  ros::NodeHandle_<ArduinoHardware,
+    NH_MAX_SUBSCRIBERS,
+    NH_MAX_PUBLISHERS,
+    NH_INPUT_SIZE,
+    NH_OUTPUT_SIZE> nh;
+#endif
 
 void setupM5stackROS(char *name) {
   M5.begin();

--- a/m5stack_ros/sketches/Grove-Multichannel-Gas-Sensor-V2/Grove-Multichannel-Gas-Sensor-V2.ino
+++ b/m5stack_ros/sketches/Grove-Multichannel-Gas-Sensor-V2/Grove-Multichannel-Gas-Sensor-V2.ino
@@ -1,5 +1,4 @@
 #include <Grove-Multichannel-Gas-Sensor-V2.h>
-#include <m5stack_ros.h>
 #include <std_msgs/UInt16.h>
 
 std_msgs::UInt16 gas_v2_102b_msg;

--- a/m5stack_ros/sketches/TGS_Gas_Sensors/TGS_Gas_Sensors.ino
+++ b/m5stack_ros/sketches/TGS_Gas_Sensors/TGS_Gas_Sensors.ino
@@ -1,5 +1,4 @@
 #include <TGS_Gas_Sensors.h>
-#include <m5stack_ros.h>
 #include <std_msgs/UInt16.h>
 
 std_msgs::UInt16 tgs_gas_analog_msg;


### PR DESCRIPTION
AtomS3 support in m5stack_ros

~WIP!! Currently still not working well and will be corrected.~  
Check that it is working with `Grove-Multichannel-Gas-Sensor-V2` and `TGS_Gas_Sensors`.  

As I mentioned in the README, the following is required to use atoms3.
- Set `USB CDC On Boot: Enabled` and `USB Mode: Hardware CDC and JTAG`
- Create a NodeHandle_ instance use implementation like https://github.com/sktometometo/smart_device_protocol/blob/develop/arduino_lib/ArduinoAtomS3Hardware.h
